### PR TITLE
Hotfix/35 fix errors from linter

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,27 @@
+name: MISRA-C Linting with Clang-Tidy
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install Clang-Tidy
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy libcunit1 libcunit1-doc libcunit1-dev
+
+      - name: Create .clang-tidy Configuration
+        run: |
+          echo 'Checks: >' > .clang-tidy
+          echo '  -*,' >> .clang-tidy
+          echo '  misra-c2012-*,' >> .clang-tidy
+          echo '  readability-*,' >> .clang-tidy
+          echo '  bugprone-*,' >> .clang-tidy
+          echo '  performance-*' >> .clang-tidy
+          echo 'WarningsAsErrors: "*"' >> .clang-tidy
+      - name: Run Clang-Tidy on Source Files
+        run: |
+          clang-tidy src/*.c test/*.c -- -std=c99

--- a/src/can_socket.c
+++ b/src/can_socket.c
@@ -1,4 +1,3 @@
-#include "can_socket.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,24 +7,23 @@
 #include <sys/socket.h>
 #include <linux/can.h>
 #include <linux/can/raw.h>
-#include <net/if.h>
-#include <sys/ioctl.h>
-#include <linux/can.h>
+#include <linux/if.h>
+#include "can_socket.h"
 
 #define SOCKET_ERROR         (-1)
 #define OPERATION_SUCCESS    (0)
 #define MAX_INTERFACE_LEN    (IFNAMSIZ - 1U)
 #define CAN_FRAME_SIZE       (sizeof(struct can_frame))
 
-static int32_t validate_interface(const char *interface)
+static int validate_interface(const char *interface)
 {
     const size_t len = strlen(interface);
     return (len > 0U) && (len <= MAX_INTERFACE_LEN) ? OPERATION_SUCCESS : SOCKET_ERROR;
 }
 
-int32_t create_can_socket(const char *interface)
+int create_can_socket(const char *interface)
 {
-    int32_t sock = SOCKET_ERROR;
+    int sock = SOCKET_ERROR;
     struct sockaddr_can addr;
     struct ifreq ifr;
 
@@ -70,11 +68,11 @@ int32_t create_can_socket(const char *interface)
     return sock;
 }
 
-void close_can_socket(int32_t sock)
+void close_can_socket(int sock)
 {
     if (sock >= 0)
     {
-        (void)close(sock);
+        close(sock);
     }
 }
 
@@ -91,7 +89,7 @@ int send_can_frame(int sock, const struct can_frame *frame)
     return OPERATION_SUCCESS;
 }
 
-int32_t receive_can_frame(int32_t sock, struct can_frame *frame)
+int receive_can_frame(int sock, struct can_frame *frame)
 {
     const ssize_t received_bytes = read(sock, frame, CAN_FRAME_SIZE);
     

--- a/src/can_socket.c
+++ b/src/can_socket.c
@@ -8,6 +8,9 @@
 #include <sys/socket.h>
 #include <linux/can.h>
 #include <linux/can/raw.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <linux/can.h>
 
 #define SOCKET_ERROR         (-1)
 #define OPERATION_SUCCESS    (0)
@@ -75,7 +78,7 @@ void close_can_socket(int32_t sock)
     }
 }
 
-int32_t send_can_frame(int32_t sock, const struct can_frame *frame)
+int send_can_frame(int sock, const struct can_frame *frame)
 {
     const ssize_t sent_bytes = write(sock, frame, CAN_FRAME_SIZE);
     

--- a/src/can_socket.c
+++ b/src/can_socket.c
@@ -1,54 +1,108 @@
 #include "can_socket.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
 
-int create_can_socket(const char *interface) {
-    int sock;
+#define SOCKET_ERROR         (-1)
+#define OPERATION_SUCCESS    (0)
+#define MAX_INTERFACE_LEN    (IFNAMSIZ - 1U)
+#define CAN_FRAME_SIZE       (sizeof(struct can_frame))
+
+static int32_t validate_interface(const char *interface)
+{
+    const size_t len = strlen(interface);
+    return (len > 0U) && (len <= MAX_INTERFACE_LEN) ? OPERATION_SUCCESS : SOCKET_ERROR;
+}
+
+int32_t create_can_socket(const char *interface)
+{
+    int32_t sock = SOCKET_ERROR;
     struct sockaddr_can addr;
     struct ifreq ifr;
 
-    // Create CAN socket
-    if ((sock = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+    if (validate_interface(interface) != OPERATION_SUCCESS)
+    {
+        (void)fprintf(stderr, "Invalid interface name\n");
+        return SOCKET_ERROR;
+    }
+
+    /* Create CAN socket */
+    sock = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (sock < 0)
+    {
         perror("Error creating socket");
-        return -1;
+        return SOCKET_ERROR;
     }
 
-    // Set CAN interface
-    strcpy(ifr.ifr_name, interface);
-    if (ioctl(sock, SIOCGIFINDEX, &ifr) < 0) {
+    /* Configure interface */
+    (void)memset(&ifr, 0, sizeof(ifr));
+    (void)strncpy(ifr.ifr_name, interface, MAX_INTERFACE_LEN);
+    ifr.ifr_name[MAX_INTERFACE_LEN] = '\0';
+
+    if (ioctl(sock, SIOCGIFINDEX, &ifr) < 0)
+    {
         perror("Error getting interface index");
-        close(sock);
-        return -1;
+        (void)close(sock);
+        return SOCKET_ERROR;
     }
 
-    memset(&addr, 0, sizeof(addr));
+    /* Bind socket */
+    (void)memset(&addr, 0, sizeof(addr));
     addr.can_family = AF_CAN;
     addr.can_ifindex = ifr.ifr_ifindex;
 
-    if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
         perror("Error binding socket");
-        close(sock);
-        return -1;
+        (void)close(sock);
+        return SOCKET_ERROR;
     }
 
     return sock;
 }
 
-void close_can_socket(int sock) {
-    close(sock);
+void close_can_socket(int32_t sock)
+{
+    if (sock >= 0)
+    {
+        (void)close(sock);
+    }
 }
 
-int send_can_frame(int sock, struct can_frame *frame) {
-    if (write(sock, frame, sizeof(*frame)) != sizeof(*frame)) {
+int32_t send_can_frame(int32_t sock, const struct can_frame *frame)
+{
+    const ssize_t sent_bytes = write(sock, frame, CAN_FRAME_SIZE);
+    
+    if (sent_bytes != (ssize_t)CAN_FRAME_SIZE)
+    {
         perror("Error sending frame");
-        return -1;
+        return SOCKET_ERROR;
     }
-    return 0;
+    
+    return OPERATION_SUCCESS;
 }
 
-int receive_can_frame(int sock, struct can_frame *frame) {
-    int nbytes = read(sock, frame, sizeof(*frame));
-    if (nbytes < 0) {
+int32_t receive_can_frame(int32_t sock, struct can_frame *frame)
+{
+    const ssize_t received_bytes = read(sock, frame, CAN_FRAME_SIZE);
+    
+    if (received_bytes < 0)
+    {
         perror("Error receiving frame");
-        return -1;
+        return SOCKET_ERROR;
     }
-    return 0;
+    
+    if (received_bytes != (ssize_t)CAN_FRAME_SIZE)
+    {
+        (void)fprintf(stderr, "Incomplete frame received\n");
+        return SOCKET_ERROR;
+    }
+    
+    return OPERATION_SUCCESS;
 }

--- a/src/can_socket.h
+++ b/src/can_socket.h
@@ -16,7 +16,7 @@ int create_can_socket(const char *interface);
 void close_can_socket(int sock);
 
 //define function to send one CAN frame
-int send_can_frame(int sock, struct can_frame *frame);
+int send_can_frame(int sock, const struct can_frame *frame);
 
 //define function to receive one CAN frame
 int receive_can_frame(int sock, struct can_frame *frame);

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -42,6 +42,6 @@ int main(void)
         }
     }
 
-    (void)close_can_socket(sock);
+    close_can_socket(sock);
     return SUCCESS_CODE;
 }

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -1,19 +1,47 @@
 #include "can_socket.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-int main() {
-    int sock = create_can_socket("vcan0");
-    if (sock < 0) return 1;
+#define CAN_INTERFACE      ("vcan0")
+#define SUCCESS_CODE       (0)
+#define ERROR_CODE         (1)
+#define RECEIVE_SUCCESS    (1)
 
+int main(void)
+{
+    int sock = -1;
     struct can_frame frame;
+    int32_t receive_result;
+    
+    sock = create_can_socket(CAN_INTERFACE);
+    if (sock < 0)
+    {
+        return ERROR_CODE;
+    }
 
-    // Receive CAN frame
-    while (1) {
-        if (receive_can_frame(sock, &frame) > 0) {
-            printf("Received CAN ID: %X Data: %s\n", frame.can_id, frame.data);
-            fflush(stdout);
+    (void)memset(&frame, 0, sizeof(frame));
+
+    for(;;)
+    {
+        receive_result = receive_can_frame(sock, &frame);
+        if (receive_result == RECEIVE_SUCCESS)
+        {
+            (void)printf("Received CAN ID: %04X Data: ", (unsigned int)frame.can_id);
+            for(uint8_t i = 0U; i < frame.can_dlc; i++)
+            {
+                (void)printf("%02X ", frame.data[i]);
+            }
+            (void)printf("\n");
+            (void)fflush(stdout);
+        }
+        else if (receive_result < 0)
+        {
+            break;
         }
     }
 
-    close_can_socket(sock);
-    return 0;
+    (void)close_can_socket(sock);
+    return SUCCESS_CODE;
 }

--- a/src/sender.c
+++ b/src/sender.c
@@ -16,7 +16,7 @@ int main(void)
 {
     int sock = -1;
     struct can_frame frame;
-    uint8_t i;
+    uint8_t frame_index;
 
     sock = create_can_socket(CAN_INTERFACE);
     if (sock < 0)
@@ -29,11 +29,11 @@ int main(void)
     frame.can_dlc = CAN_DLC;
     (void)memcpy(frame.data, DATA_STRING, sizeof(DATA_STRING) - 1U);
 
-    for (i = 0U; i < NUM_SENDS; i++)
+    for (frame_index = 0U; frame_index < NUM_SENDS; frame_index++)
     {
         if (send_can_frame(sock, &frame) < 0)
         {
-            (void)close_can_socket(sock);
+            close_can_socket(sock);
             return EXIT_FAILURE;
         }
 
@@ -41,7 +41,7 @@ int main(void)
     }
 
     (void)printf("CAN Frame sent\n");
-    (void)close_can_socket(sock);
+    close_can_socket(sock);
 
     return EXIT_SUCCESS;
 }

--- a/src/sender.c
+++ b/src/sender.c
@@ -1,25 +1,47 @@
 #include "can_socket.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-int main() {
-    int sock = create_can_socket("vcan0");
-    if (sock < 0) return 1;
+#define CAN_INTERFACE ("vcan0")
+#define NUM_SENDS     (5U)
+#define SLEEP_TIME    (5U)
+#define CAN_ID        (0x123U)
+#define CAN_DLC       (8U)
+#define DATA_STRING   "Hi CAN"
 
-    // Set CAN frame
+int main(void)
+{
+    int sock = -1;
     struct can_frame frame;
-    frame.can_id = 0x123;
-    frame.can_dlc = 8;
-    strcpy((char *)frame.data, "Hi CAN");
+    uint8_t i;
 
-    for (int i = 0; i < 5; i++) {
-        // Send CAN frame
-        if (send_can_frame(sock, &frame) < 0) {
-            close_can_socket(sock);
-            return 1;
-        }
-        sleep(5);
+    sock = create_can_socket(CAN_INTERFACE);
+    if (sock < 0)
+    {
+        return EXIT_FAILURE;
     }
 
-    printf("CAN Frame sent\n");
-    close_can_socket(sock);
-    return 0;
+    (void)memset(&frame, 0, sizeof(frame));
+    frame.can_id = CAN_ID;
+    frame.can_dlc = CAN_DLC;
+    (void)memcpy(frame.data, DATA_STRING, sizeof(DATA_STRING) - 1U);
+
+    for (i = 0U; i < NUM_SENDS; i++)
+    {
+        if (send_can_frame(sock, &frame) < 0)
+        {
+            (void)close_can_socket(sock);
+            return EXIT_FAILURE;
+        }
+
+        (void)sleep(SLEEP_TIME);
+    }
+
+    (void)printf("CAN Frame sent\n");
+    (void)close_can_socket(sock);
+
+    return EXIT_SUCCESS;
 }

--- a/test/test_can_socket.c
+++ b/test/test_can_socket.c
@@ -32,7 +32,7 @@ static void test_create_can_socket(void)
     CU_ASSERT(sock >= 0);
     if (sock >= 0) 
     {
-        (void)close_can_socket(sock);
+        close_can_socket(sock);
     }
 }
 
@@ -65,7 +65,7 @@ static void test_send_receive_can_frame(void)
     CU_ASSERT(send_can_frame(sock, &frame) == 0);
     CU_ASSERT(receive_can_frame(sock, &received_frame) == 0);
 
-    (void)close_can_socket(sock);
+    close_can_socket(sock);
 }
 
 static void test_close_can_socket(void) 
@@ -74,7 +74,7 @@ static void test_close_can_socket(void)
     CU_ASSERT(sock >= 0);
     if (sock >= 0) 
     {
-        (void)close_can_socket(sock);
+        close_can_socket(sock);
     }
 }
 
@@ -104,7 +104,7 @@ static void test_receive_can_frame_closed_socket(void)
     
     if (sock >= 0)
     {
-        (void)close_can_socket(sock);
+        close_can_socket(sock);
     }
     
     struct can_frame frame;
@@ -119,14 +119,14 @@ int main(void)
 
     if (CU_initialize_registry() != CUE_SUCCESS)
     {
-        (void)CU_cleanup_registry();
+        CU_cleanup_registry();
         return (int)CU_get_error();
     }
 
     pSuite = CU_add_suite("CAN Socket Test Suite", init_suite, clean_suite);
     if (pSuite == NULL)
     {
-        (void)CU_cleanup_registry();
+        CU_cleanup_registry();
         return (int)CU_get_error();
     }
 
@@ -141,14 +141,14 @@ int main(void)
 
     if (!tests_added)
     {
-        (void)CU_cleanup_registry();
+        CU_cleanup_registry();
         return (int)CU_get_error();
     }
 
     CU_basic_set_mode(CU_BRM_VERBOSE);
     (void)CU_basic_run_tests();
     error_code = CU_get_error();
-    (void)CU_cleanup_registry();
+    CU_cleanup_registry();
 
     return (int)error_code;
 }

--- a/test/test_can_socket.c
+++ b/test/test_can_socket.c
@@ -2,102 +2,153 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include <CUnit/Basic.h>
 #include "../src/can_socket.h"
 
-#define TEST_INTERFACE "vcan0"
-#define INVALID_INTERFACE "any_if"
+#define TEST_INTERFACE ("vcan0")
+#define INVALID_INTERFACE ("any_if")
 
-int init_suite(void) { return 0; }
-int clean_suite(void) { return 0; }
+#define CAN_ID  (0x123U)
+#define CAN_DLC (2U)
+#define DATA_0  (0XABU)
+#define DATA_1  (0xCDU)
 
-void test_create_can_socket() {
-    int sock = create_can_socket(TEST_INTERFACE);
-    CU_ASSERT(sock >= 0);
-    if (sock >= 0) close_can_socket(sock);
+static int init_suite(void) 
+{ 
+    return 0; 
 }
 
-void test_create_can_socket_invalid() {
-    int sock = create_can_socket(INVALID_INTERFACE);
+static int clean_suite(void) 
+{ 
+    return 0; 
+}
+
+static void test_create_can_socket(void) 
+{
+    int sock = -1;
+    
+    sock = create_can_socket(TEST_INTERFACE);
+    CU_ASSERT(sock >= 0);
+    if (sock >= 0) 
+    {
+        (void)close_can_socket(sock);
+    }
+}
+
+static void test_create_can_socket_invalid(void) 
+{
+    const int sock = create_can_socket(INVALID_INTERFACE);
     CU_ASSERT(sock == -1);
 }
 
-// integration test
-void test_send_receive_can_frame() {
-    int sock = create_can_socket(TEST_INTERFACE);
-    CU_ASSERT(sock >= 0);
-    if (sock < 0) return;
-
+/* Integration test */
+static void test_send_receive_can_frame(void) 
+{
+    int sock = -1;
     struct can_frame frame;
-    memset(&frame, 0, sizeof(frame));
-    frame.can_id = 0x123;
-    frame.can_dlc = 2;
-    frame.data[0] = 0xAB;
-    frame.data[1] = 0xCD;
+    struct can_frame received_frame;
+    
+    sock = create_can_socket(TEST_INTERFACE);
+    CU_ASSERT(sock >= 0);
+    if (sock < 0) 
+    {
+        return;
+    }
+
+    (void)memset(&frame, 0, sizeof(frame));
+    frame.can_id = CAN_ID;
+    frame.can_dlc = CAN_DLC;
+    frame.data[0] = DATA_0;
+    frame.data[1] = DATA_1;
 
     CU_ASSERT(send_can_frame(sock, &frame) == 0);
-    
-    struct can_frame received_frame;
     CU_ASSERT(receive_can_frame(sock, &received_frame) == 0);
-    
-    close_can_socket(sock);
+
+    (void)close_can_socket(sock);
 }
 
-void test_close_can_socket() {
+static void test_close_can_socket(void) 
+{
     int sock = create_can_socket(TEST_INTERFACE);
     CU_ASSERT(sock >= 0);
-    if (sock >= 0) close_can_socket(sock);
+    if (sock >= 0) 
+    {
+        (void)close_can_socket(sock);
+    }
 }
 
-void test_send_can_frame_invalid_socket() {
+static void test_send_can_frame_invalid_socket(void) 
+{
     struct can_frame frame;
-    memset(&frame, 0, sizeof(frame));
-    frame.can_id = 0x123;
-    frame.can_dlc = 2;
-    frame.data[0] = 0xAB;
-    frame.data[1] = 0xCD;
+    
+    (void)memset(&frame, 0, sizeof(frame));
+    frame.can_id = CAN_ID;
+    frame.can_dlc = CAN_DLC;
+    frame.data[0] = DATA_0;
+    frame.data[1] = DATA_1;
     
     CU_ASSERT(send_can_frame(-1, &frame) == -1);
 }
 
-void test_receive_can_frame_invalid_socket() {
+static void test_receive_can_frame_invalid_socket(void) 
+{
     struct can_frame frame;
     CU_ASSERT(receive_can_frame(-1, &frame) == -1);
 }
 
-void test_receive_can_frame_closed_socket() {
+static void test_receive_can_frame_closed_socket(void) 
+{
     int sock = create_can_socket(TEST_INTERFACE);
     CU_ASSERT(sock >= 0);
     
-    close_can_socket(sock);
+    if (sock >= 0)
+    {
+        (void)close_can_socket(sock);
+    }
+    
     struct can_frame frame;
     CU_ASSERT(receive_can_frame(sock, &frame) == -1);
 }
 
-int main() {
+int main(void)
+{
     CU_pSuite pSuite = NULL;
+    CU_ErrorCode error_code = CUE_SUCCESS;
+    bool tests_added = true;
 
-    if (CUE_SUCCESS != CU_initialize_registry()) return CU_get_error();
-
-    pSuite = CU_add_suite("CAN Socket Test Suite", init_suite, clean_suite);
-    if (!pSuite) {
-        CU_cleanup_registry();
-        return CU_get_error();
+    if (CU_initialize_registry() != CUE_SUCCESS)
+    {
+        (void)CU_cleanup_registry();
+        return (int)CU_get_error();
     }
 
-    if (!CU_add_test(pSuite, "Test CAN socket creation", test_create_can_socket) ||
-        !CU_add_test(pSuite, "Test CAN socket creation with invalid interface", test_create_can_socket_invalid) ||
-        !CU_add_test(pSuite, "Test send and receive CAN frame", test_send_receive_can_frame) ||
-        !CU_add_test(pSuite, "Test send CAN frame with invalid socket", test_send_can_frame_invalid_socket) ||
-        !CU_add_test(pSuite, "Test receive CAN frame with invalid socket", test_receive_can_frame_invalid_socket) ||
-        !CU_add_test(pSuite, "Test receive CAN frame with closed socket", test_receive_can_frame_closed_socket) ||
-        !CU_add_test(pSuite, "Test close CAN socket", test_close_can_socket)) {
-        CU_cleanup_registry();
-        return CU_get_error();
+    pSuite = CU_add_suite("CAN Socket Test Suite", init_suite, clean_suite);
+    if (pSuite == NULL)
+    {
+        (void)CU_cleanup_registry();
+        return (int)CU_get_error();
+    }
+
+    /* Add individual tests */
+    tests_added = tests_added && (CU_add_test(pSuite, "Test CAN socket creation", test_create_can_socket) != NULL);
+    tests_added = tests_added && (CU_add_test(pSuite, "Test CAN socket creation with invalid interface", test_create_can_socket_invalid) != NULL);
+    tests_added = tests_added && (CU_add_test(pSuite, "Test send and receive CAN frame", test_send_receive_can_frame) != NULL);
+    tests_added = tests_added && (CU_add_test(pSuite, "Test send CAN frame with invalid socket", test_send_can_frame_invalid_socket) != NULL);
+    tests_added = tests_added && (CU_add_test(pSuite, "Test receive CAN frame with invalid socket", test_receive_can_frame_invalid_socket) != NULL);
+    tests_added = tests_added && (CU_add_test(pSuite, "Test receive CAN frame with closed socket", test_receive_can_frame_closed_socket) != NULL);
+    tests_added = tests_added && (CU_add_test(pSuite, "Test close CAN socket", test_close_can_socket) != NULL);
+
+    if (!tests_added)
+    {
+        (void)CU_cleanup_registry();
+        return (int)CU_get_error();
     }
 
     CU_basic_set_mode(CU_BRM_VERBOSE);
-    CU_basic_run_tests();
-    CU_cleanup_registry();
-    return CU_get_error();
+    (void)CU_basic_run_tests();
+    error_code = CU_get_error();
+    (void)CU_cleanup_registry();
+
+    return (int)error_code;
 }


### PR DESCRIPTION
Fix errors related to linting concerning headers, variables, data types and redundancy.